### PR TITLE
#2743 map guide hover tooltip ready

### DIFF
--- a/src/components/MapGuide/index.tsx
+++ b/src/components/MapGuide/index.tsx
@@ -1,101 +1,71 @@
-import { useEffect, useRef, useState } from 'react';
 import Button from '@mui/material/Button';
-import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
-import Paper, { PaperProps } from '@mui/material/Paper';
-import Backdrop, { BackdropProps } from '@mui/material/Backdrop';
-import Draggable from 'react-draggable';
-import CloseIcon from '@mui/icons-material/Close';
+import { styled } from '@mui/material/styles';
+import Tooltip, { TooltipProps, tooltipClasses } from '@mui/material/Tooltip';
 
 import {
-    StyledMapGuideDialog,
     StyledMapGuideButton,
-    StyledDialogTitle,
-    CloseButton,
+    StyledTooltipTitle,
+    StyledTooltipContainer,
 } from './styled';
 
-const PaperComponent = (props: PaperProps) => {
+import React from 'react';
+
+const StyledMapGuideTooltip = styled(
+    ({ className, ...props }: TooltipProps) => (
+        <Tooltip {...props} classes={{ popper: className }} />
+    ),
+)(({ theme }) => ({
+    [`& .${tooltipClasses.tooltip}`]: {
+        backgroundColor: '#0094e2',
+        color: ' #fff',
+        maxWidth: 1050,
+        fontSize: theme.typography.pxToRem(20),
+        border: '1px solid #dadde9',
+        fontFamily: 'Inter, Helvetica, Arial, sans-serif',
+        padding: '0.5rem 2.4rem',
+    },
+}));
+
+const StyledMapGuideContext: React.FC = () => {
     return (
-        <Draggable
-            handle="#map-guide"
-            cancel={'[class*="MuiDialogContent-root"]'}
-        >
-            <Paper {...props} />
-        </Draggable>
+        <StyledTooltipContainer>
+            <StyledTooltipTitle>
+                Welcome to Global.health Map!
+            </StyledTooltipTitle>
+            <p>
+                These geospatial data visualisations allow you to explore our
+                Monkeypox line-list dataset.
+                <br />
+                <br />
+                <strong>Country View:</strong> Click on a country to see
+                available line-list data in that country. You can also use the
+                left-hand navigation to search or select a country. Darker
+                colours indicate more available line-list data.
+            </p>
+        </StyledTooltipContainer>
     );
 };
 
-const BackdropComponent = (props: BackdropProps) => {
-    return <Backdrop invisible {...props} />;
-};
-
 export const MapGuide: React.FC = () => {
-    const [open, setOpen] = useState(false);
-
-    const handleClickOpen = () => () => {
-        setOpen(true);
-    };
-
-    const handleClose = () => {
-        setOpen(false);
-    };
-
-    const descriptionElementRef = useRef<HTMLElement>(null);
-    useEffect(() => {
-        if (open) {
-            const { current: descriptionElement } = descriptionElementRef;
-            if (descriptionElement !== null) {
-                descriptionElement.focus();
-            }
-        }
-    }, [open]);
-
     return (
         <StyledMapGuideButton>
-            <Button onClick={handleClickOpen()}>
-                <svg
-                    className="MuiSvgIcon-root"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                >
-                    <path d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"></path>
-                </svg>
-                Map guide
-            </Button>
-            <StyledMapGuideDialog
-                fullWidth
-                maxWidth="lg"
-                open={open}
-                onClose={handleClose}
-                PaperComponent={PaperComponent}
-                BackdropComponent={BackdropComponent}
-                scroll="paper"
-                aria-labelledby="map-guide"
+            <StyledMapGuideTooltip
+                arrow
+                title={<StyledMapGuideContext />}
+                placement="bottom-end"
             >
-                <StyledDialogTitle id="map-guide">
-                    Welcome to Global.health Map!
-                    <CloseButton aria-label="close" onClick={handleClose}>
-                        <CloseIcon />
-                    </CloseButton>
-                </StyledDialogTitle>
-                <DialogContent>
-                    <DialogContentText
-                        ref={descriptionElementRef}
-                        tabIndex={-1}
+                <Button disableRipple>
+                    <svg
+                        className="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
                     >
-                        These geospatial data visualisations allow you to
-                        explore our Monkeypox line-list dataset.
-                        <br />
-                        <br />
-                        <strong>Country View:</strong> Click on a country to see
-                        available line-list data in that country. You can also
-                        use the left-hand navigation to search or select a
-                        country. Darker colours indicate more available
-                        line-list data.
-                    </DialogContentText>
-                </DialogContent>
-            </StyledMapGuideDialog>
+                        <path d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"></path>
+                    </svg>
+                    Map guide
+                </Button>
+            </StyledMapGuideTooltip>
         </StyledMapGuideButton>
     );
 };

--- a/src/components/MapGuide/styled.ts
+++ b/src/components/MapGuide/styled.ts
@@ -1,7 +1,4 @@
 import { styled } from '@mui/material/styles';
-import Dialog from '@mui/material/Dialog';
-import DialogTitle from '@mui/material/DialogTitle';
-import IconButton from '@mui/material/IconButton';
 
 export const StyledMapGuideButton = styled('div')`
     margin-left: 15px;
@@ -36,31 +33,20 @@ export const StyledMapGuideButton = styled('div')`
     }
 `;
 
-export const StyledMapGuideDialog = styled(Dialog)`
-    .MuiDialog-paperScrollPaper {
-        background: #0094e2;
-        color: #fff;
-    }
-    h1,
+export const StyledTooltipContainer = styled('div')`
     p,
     a {
         color: #fff;
     }
     p {
+        padding: 1.4rem 0;
+        font-size: 1.6rem;
         margin: 1rem auto;
         font-family: Inter, Helvetica, Arial, sans-serif;
     }
-    h1 {
-        font-weight: 400;
-        text-align: center;
-    }
-    .MuiButton-text {
-        color: #fff;
-    }
 `;
 
-export const StyledDialogTitle = styled(DialogTitle)(() => ({
-    cursor: 'move',
+export const StyledTooltipTitle = styled('h2')(() => ({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
@@ -68,10 +54,6 @@ export const StyledDialogTitle = styled(DialogTitle)(() => ({
     textAlign: 'center',
     width: '100%',
     position: 'relative',
-}));
-
-export const CloseButton = styled(IconButton)(() => ({
-    color: '#fff',
-    position: 'absolute',
-    right: '2rem',
+    padding: '1.6rem 2.4rem',
+    fontWeight: 450,
 }));


### PR DESCRIPTION
Changes:
- map guide container appears as a tooltip after hovering on the map guide button 
- map guide container no longer appears after clicking on a button
- map guide button click action disabled
- map guide container no longer has a closing button
- map guide container disappears after hovering outside itself or the map guide button