### PR TITLE
#2832 blank section after clicking drc on Safari

### DIFF
--- a/src/containers/CountryView/index.tsx
+++ b/src/containers/CountryView/index.tsx
@@ -103,6 +103,12 @@ const CountryView: React.FC = () => {
 
         const bounds = lookupTableData[countryCode].bounds;
         map.current?.fitBounds(bounds);
+
+        //on some browsers the blank space is added below the body element when using fitBounds function
+        //this is to manually scroll to top of the page where map is located
+        setTimeout(() => {
+            scrollTo(0, 0);
+        }, 100);
     }, [selectedCountry]);
 
     // Setup map


### PR DESCRIPTION
After choosing a country from the sidebar that is not in the user's view a blank space below the map is created. In Chrome the view is automatically focused on the chosen country and blank space disappears but on Safari there is a need to scroll up manually back to where the map is located.

Changes:
- added scrolling up to the map in code after choosing a country