### PR TITLE
#2821 error page for salvador chart view

### DIFF
--- a/src/components/ChartSlider/index.tsx
+++ b/src/components/ChartSlider/index.tsx
@@ -21,7 +21,7 @@ import {
     URLToFilters,
 } from 'utils/helperFunctions';
 
-const minDistance = 5;
+let minDistance = 5;
 
 function getLabel(dates: Date[], selectedDate: number | undefined) {
     if (selectedDate === undefined || !dates || dates.length === 0) return '';
@@ -52,6 +52,9 @@ export default function ChartSlider() {
                       selectedCountry,
                   )
                 : allTimeseriesDates;
+
+        minDistance = dates.length > 5 ? 5 : dates.length - 1;
+
         const newChartValues = URLToFilters(location.search);
         const dateRange = spaceBetweenDatesParams(
             Number(newChartValues.startDate) || 0,

--- a/src/utils/helperFunctions.ts
+++ b/src/utils/helperFunctions.ts
@@ -146,6 +146,8 @@ const getNDaysAverage = (
 ): number | undefined => {
     //if first 7 days return undefined
 
+    if (!timeseriesCountData[8]) return;
+
     if (
         nDays >= idx + 1 &&
         compareAsc(data[0].date, timeseriesCountData[8].date) === -1


### PR DESCRIPTION
Changes:
- Added check for countries that have less than 8 days of data to prevent the error caused by it (unable to make 7-day moving chart with less than 8 days)
- Changed minimal distance on chart slider for countries that have less than 5 data dates 
